### PR TITLE
faulty return in openam passport promise chain causes any error to be converted into 401

### DIFF
--- a/lib/redisOpenAM.js
+++ b/lib/redisOpenAM.js
@@ -18,13 +18,19 @@ function createBasicStrategy(options) {
             foundToken;
 
         return getRedis(redis, hashedHeader)
-            .then(postToken)
-            .spread(cacheAndGetTokenInfo)
-            .spread(returnToken)
+            .then(function(token) {
+                if (token) {
+                    return done(null, token);
+                } else {
+                    return postToken(token)
+                        .spread(cacheAndGetTokenInfo)
+                        .spread(returnToken);
+                }
+            })
             .catch(invalidate);
 
+
         function postToken(token) {
-            if (token) return done(null, token);
             return $http.post(URL, {
                 form: {
                     client_id: options.client_id,
@@ -34,7 +40,7 @@ function createBasicStrategy(options) {
                     password: password,
                     scope: scopes
                 },
-                error: false
+                error: true
             });
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-openam-agco",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Passport strategy to query OpenAM for token_info with Redis cache",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
implemented the promise flow as in oauth2
at this point the .done call result is no longer passed down into the promise chain
