### PR TITLE
[#1058] Caches whole tokenInfo, maps agcoUUID to sub

### DIFF
--- a/lib/redisOpenAM.js
+++ b/lib/redisOpenAM.js
@@ -14,23 +14,19 @@ function createBasicStrategy(options) {
             hashedHeader = MD5(header),
             URL = options.openAMBaseURL,
             infoURL = options.openAMInfoURL,
-            scopes = options.scope.join('%20'),
-            foundToken;
+            scopes = options.scope.join('%20');
 
         return getRedis(redis, hashedHeader)
-            .then(function(token) {
-                if (token) {
-                    return done(null, token);
-                } else {
-                    return postToken(token)
-                        .spread(cacheAndGetTokenInfo)
-                        .spread(returnToken);
-                }
+            .then(function(tokenInfo) {
+                if (tokenInfo) return done(null, JSON.parse(tokenInfo));
+                return postToken()
+                    .spread(getandCacheTokenInfo)
+                    .then(returnToken);
             })
             .catch(invalidate);
 
 
-        function postToken(token) {
+        function postToken() {
             return $http.post(URL, {
                 form: {
                     client_id: options.client_id,
@@ -40,39 +36,38 @@ function createBasicStrategy(options) {
                     password: password,
                     scope: scopes
                 },
-                error: true
+                error: true,
+                json:true
             });
         }
 
-        function cacheAndGetTokenInfo(res, body) {
-            var parsedBody = JSON.parse(body);
-
-            foundToken = parsedBody.access_token;
-
-            return promise.all([
-                cacheToken(parsedBody),
-                getTokenInfo()
-            ]);
+        function getandCacheTokenInfo(res, body) {
+            return getTokenInfo(body)
+                .spread(cacheToken);
         }
 
-        function cacheToken(parsedBody) {
-            var expiry = parsedBody.expires_in;
+        function getTokenInfo(tokenBody) {
+            return $http.get(infoURL+'?access_token='+tokenBody.access_token, {json: true})
+                .spread(function(res, infoBody) {
+                    if (infoBody.error ||
+                        res.statusCode === 404) return done(null, false);
+                    infoBody.sub = infoBody.agcoUUID;
+                    return [hashedHeader, infoBody, tokenBody.expires_in];
+                });
+        }
 
+        function cacheToken(hashedHeader, tokenInfo, expiry) {
             redis.multi();
-            redis.set(hashedHeader, foundToken);
+            redis.set(hashedHeader, JSON.stringify(tokenInfo));
             redis.expire(hashedHeader, expiry);
-            return redis.exec();
+            return redis.exec().then(function(){return tokenInfo;});
         }
 
-        function getTokenInfo() {
-            return $http.get(infoURL+'?access_token='+foundToken, {json: true});
+        function returnToken(tokenInfo) {
+            return done(null, tokenInfo);
         }
 
-        function returnToken(redisArgs, tokenInfo) {
-            return done(null, tokenInfo[1]);
-        }
-
-        function invalidate(err) {
+        function invalidate() {
             return done(null, false);
         }
     });

--- a/lib/redisOpenAM.js
+++ b/lib/redisOpenAM.js
@@ -49,10 +49,10 @@ function createBasicStrategy(options) {
         function getTokenInfo(tokenBody) {
             return $http.get(infoURL+'?access_token='+tokenBody.access_token, {json: true})
                 .spread(function(res, infoBody) {
-                    if (infoBody.error ||
-                        res.statusCode === 404) return done(null, false);
+                    var user = {sub: infoBody.agcoUUID,
+                                tokenInfo: infoBody};
                     infoBody.sub = infoBody.agcoUUID;
-                    return [hashedHeader, infoBody, tokenBody.expires_in];
+                    return [hashedHeader, user, tokenBody.expires_in];
                 });
         }
 

--- a/lib/redisOpenAM.js
+++ b/lib/redisOpenAM.js
@@ -49,10 +49,10 @@ function createBasicStrategy(options) {
         function getTokenInfo(tokenBody) {
             return $http.get(infoURL+'?access_token='+tokenBody.access_token, {json: true})
                 .spread(function(res, infoBody) {
-                    if (infoBody.error ||
-                        res.statusCode === 404) return done(null, false);
+                    var user = {sub: infoBody.agcoUUID,
+                                token: infoBody};
                     infoBody.sub = infoBody.agcoUUID;
-                    return [hashedHeader, infoBody, tokenBody.expires_in];
+                    return [hashedHeader, user, tokenBody.expires_in];
                 });
         }
 

--- a/test/specs.js
+++ b/test/specs.js
@@ -172,10 +172,10 @@ describe('Basic Authorization', function() {
                 var header = user + ':' + pass,
                 hashedHeader = MD5(header);
 
-                expect(requestUser.agcoUUID).to.equal("h234ljb234jkn23");
                 expect(requestUser.sub).to.equal("h234ljb234jkn23");
-                expect(requestUser.username).to.exist;
-                expect(requestUser.email).to.exist;
+                expect(requestUser.token.agcoUUID).to.equal("h234ljb234jkn23");
+                expect(requestUser.token.username).to.exist;
+                expect(requestUser.token.email).to.exist;
 
                 return db.select(1).then(getHeader).then(checkToken);
 
@@ -185,11 +185,11 @@ describe('Basic Authorization', function() {
 
                 function checkToken(token) {
                     var parsedToken = JSON.parse(token);
-                    expect(parsedToken.agcoUUID).to.equal("h234ljb234jkn23");
+                    expect(parsedToken.token.agcoUUID).to.equal("h234ljb234jkn23");
                     expect(parsedToken.sub).to.equal("h234ljb234jkn23");
                 }
 
-            }
+            });
         });
 
         it('validates with tokenInfo and cached results', function() {
@@ -197,7 +197,6 @@ describe('Basic Authorization', function() {
                 pass = 'missing';
 
             return getValidTokenInfo()
-                .then(getValidTokenInfo)
                 .spread(checkResponse);
 
             function getValidTokenInfo() {
@@ -219,10 +218,10 @@ describe('Basic Authorization', function() {
                 var header = user + ':' + pass,
                     hashedHeader = MD5(header);
 
-                expect(requestUser.agcoUUID).to.equal("h234ljb234jkn23");
                 expect(requestUser.sub).to.equal("h234ljb234jkn23");
-                expect(requestUser.username).to.exist;
-                expect(requestUser.email).to.exist;
+                expect(requestUser.token.agcoUUID).to.equal("h234ljb234jkn23");
+                expect(requestUser.token.username).to.exist;
+                expect(requestUser.token.email).to.exist;
 
                 return db.select(1).then(getHeader).then(checkToken);
 
@@ -237,7 +236,7 @@ describe('Basic Authorization', function() {
             }
         });
 
-        it('invalidates a user if openAM returns a 400 code', function() {
+        it('invalidates a user if openAM token POST returns a 401 code', function() {
             var user = 'invalid',
                 pass = 'invalid';
 
@@ -254,6 +253,47 @@ describe('Basic Authorization', function() {
             .spread(function(res, body) {
                 expect(res.statusCode).to.equal(401);
             });
+        });
+    });
+
+    describe('Error handling check', function() {
+        before(function() {
+            openAMMock
+                .post(openAMTokenPath)
+                .reply(200, {
+                    "expires_in": 599,
+                    "token_type": "Bearer",
+                    "refresh_token": "f9063e26-3a29-41ec-86de-1d0d68aa85e9",
+                    "access_token": mockToken
+                })
+                .get(openAMInfoPath+'?access_token='+mockToken)
+                .reply(404, {
+                    "error": "Not found",
+                    "error_description": "Could not read token in CTS"
+                });
+        });
+
+        after(function() {
+            return db.flushdb();
+        });
+
+        it('invalidates a user if openAM token POST returns a 404 code', function() {
+            var user = 'invalid',
+                pass = 'invalid';
+
+            return $http.get(url + '/foo', {
+                error: false,
+                auth: {
+                    user: user,
+                    pass: pass
+                },
+                json: {
+                    deviceId: true
+                }
+            })
+                .spread(function(res, body) {
+                    expect(res.statusCode).to.equal(401);
+                });
         });
     });
 });

--- a/test/specs.js
+++ b/test/specs.js
@@ -3,7 +3,7 @@ var expect = require('chai').expect,
     MD5 = require('MD5'),
     nock = require('nock'),
     redis = require('then-redis'),
-    db = redis.createClient(),
+    db = redis.createClient({database: 1}),
     express = require('express'),
     passport = require('passport'),
     app = express(),
@@ -29,7 +29,7 @@ before(function() {
             client_id: 'client_id',
             client_secret: 'client_secret',
             redis: {database: 1},
-            scope: ["UUID", "username", "email"]
+            scope: ["sub", "username", "email"]
         },
         oauth2Options = {
             openAMInfoURL: openAMBaseURL + openAMInfoPath,
@@ -60,6 +60,7 @@ before(function() {
         console.log('Test server listening at http://%s:%s', host, port);
     });
 
+    return db.flushdb();
 });
 
 describe('Basic Authorization', function() {
@@ -77,7 +78,7 @@ describe('Basic Authorization', function() {
     describe('Redis caches authentication', function() {
         var user = 'foo',
             pass = 'bar',
-            token = 'qux';
+            token = {sub: '234234'};
 
         before(function() {
             //create
@@ -87,7 +88,7 @@ describe('Basic Authorization', function() {
 
             db.multi();
             db.select(1);
-            db.set(hashedHeader, token);
+            db.set(hashedHeader, JSON.stringify(token));
 
             return db.exec();
         });
@@ -133,9 +134,9 @@ describe('Basic Authorization', function() {
                 })
                 .get(openAMInfoPath+'?access_token='+mockToken)
                 .reply(200, {
-                    "UUID": "h234ljb234jkn23",
+                    "agcoUUID": "h234ljb234jkn23",
                     "scope": [
-                        "UUID",
+                        "agcoUUID",
                         "username",
                         "email"
                     ],
@@ -165,11 +166,58 @@ describe('Basic Authorization', function() {
                     deviceId: true
                 }
             })
-            .spread(function(res, body) {
+            .spread(function checkResponse(res, body) {
                 expect(res.statusCode).to.equal(200);
 
                 var header = user + ':' + pass,
                 hashedHeader = MD5(header);
+
+                expect(requestUser.agcoUUID).to.equal("h234ljb234jkn23");
+                expect(requestUser.sub).to.equal("h234ljb234jkn23");
+                expect(requestUser.username).to.exist;
+                expect(requestUser.email).to.exist;
+
+                return db.select(1).then(getHeader).then(checkToken);
+
+                function getHeader() {
+                    return db.get(hashedHeader);
+                }
+
+                function checkToken(token) {
+                    var parsedToken = JSON.parse(token);
+                    expect(parsedToken.agcoUUID).to.equal("h234ljb234jkn23");
+                    expect(parsedToken.sub).to.equal("h234ljb234jkn23");
+                }
+
+            });
+        });
+
+        it.skip('validates with tokenInfo and cached results', function() {
+            var user = 'missing',
+                pass = 'missing';
+
+            return getValidTokenInfo()
+                .then(getValidTokenInfo)
+                .spread(checkResponse);
+
+            function getValidTokenInfo() {
+                return $http.get(url + '/foo', {
+                    error: false,
+                    auth: {
+                        user: user,
+                        pass: pass
+                    },
+                    json: {
+                        deviceId: true
+                    }
+                });
+            }
+
+            function checkResponse(res) {
+                expect(res.statusCode).to.equal(200);
+
+                var header = user + ':' + pass,
+                    hashedHeader = MD5(header);
 
                 expect(requestUser.UUID).to.exist;
                 expect(requestUser.username).to.exist;
@@ -185,7 +233,7 @@ describe('Basic Authorization', function() {
                     expect(token).to.equal(mockToken);
                 }
 
-            });
+            }
         });
 
         it('invalidates a user if openAM returns a 400 code', function() {


### PR DESCRIPTION
lib/redisOpenAM.js
- Removes some var hoisting from promise flow
- Refactors token check to make more concise
- Removes unnecessary JSON.parse
- Caches tokenInfo return
- Generally simplifies flow dependencies
- Maps agcoUUID to `sub` before it is cached

test/specs.js
- Adds test for cached object and tokenInfo
- Adds agcoUUID to return
- Checks for `sub` property

Signed-off-by: Braden O'Guinn braden.oguinn@mutualmobile.com
